### PR TITLE
Allowing user to input epsilon_i values for each observation 

### DIFF
--- a/R/doPerm.R
+++ b/R/doPerm.R
@@ -33,7 +33,7 @@ doPerm <- function(happi_results_perm,
   
   my_perm_covariate <- my_results$covariate[random_rows,] # shuffle the group labels
   
-  happi_perm_out <- happi::happi_test(outcome=my_results$outcome, 
+  happi_perm_out <- happi::happi(outcome=my_results$outcome, 
                     covariate=my_perm_covariate, 
                     quality_var=my_results$quality_var,
                     h0_param = h0_param, 

--- a/R/incomplete_loglik.R
+++ b/R/incomplete_loglik.R
@@ -21,14 +21,14 @@ incomplete_loglik <- function(xbeta,
   prob_lambda <- expit(xbeta)
   ## PT TODO: remove redundancy of the LL calculation 
   if (!firth) {
-    sum(log( (1 - epsilon) * (1 - prob_lambda[outcome == 0]) +
+    sum(log( (1 - epsilon[outcome == 0]) * (1 - prob_lambda[outcome == 0]) +
                (1 - ff[outcome == 0]) * prob_lambda[outcome == 0])) +
-      sum(log(epsilon * (1 - prob_lambda[outcome == 1]) +
+      sum(log(epsilon[outcome == 1] * (1 - prob_lambda[outcome == 1]) +
                 ff[outcome == 1] * prob_lambda[outcome == 1]))
   } else {
-    ll <-  sum(log( (1 - epsilon) * (1 - prob_lambda[outcome == 0]) +
+    ll <-  sum(log( (1 - epsilon[outcome == 0]) * (1 - prob_lambda[outcome == 0]) +
                       (1 - ff[outcome == 0]) * prob_lambda[outcome == 0])) +
-      sum(log(epsilon * (1 - prob_lambda[outcome == 1]) +
+      sum(log(epsilon[outcome == 1] * (1 - prob_lambda[outcome == 1]) +
                 ff[outcome == 1] * prob_lambda[outcome == 1]))
     penalty <- 0.5*msos::logdet(t(covariate) %*% diag(as.numeric(prob_lambda)*(
       1 - as.numeric(prob_lambda))) %*% covariate)

--- a/man/happi.Rd
+++ b/man/happi.Rd
@@ -36,7 +36,7 @@ happi(
 
 \item{change_threshold}{aalgorithm will terminate early if the likelihood changes by this percentage or less for 5 iterations in a row for both the alternative and the null}
 
-\item{epsilon}{probability of observing a gene when it should be absent; probability between 0 and 1; default is 0}
+\item{epsilon}{probability of observing a gene when it should be absent; probability between 0 and 1; default is 0. Either a single value or a vector of length n.}
 
 \item{method}{method for estimating f. Defaults to "splines" which fits a monotone spline with df determined by 
 argument spline_df; "isotone" for isotonic regression fit}

--- a/vignettes/happi-intro.Rmd
+++ b/vignettes/happi-intro.Rmd
@@ -131,7 +131,7 @@ By default, the hypothesis testing approach used by `happi` is a likelihood rati
 
 To use `happi`'s nonparametric permutation testing approach we can take our `happi` results object as an input to the function `happi::npLRT()`. This will take a bit of time to run depending on the number of permutations specified. 
 
-```{r}
+```{r, message = FALSE, warning = FALSE}
 set.seed(22)
 perm_test_result <- npLRT(happi_results, 
                           P = 500, 


### PR DESCRIPTION
Addressing issue #15  by adding in capacity for user to include a vector of known epsilon values, one for each observation. Backwards compatible if user provides a single value for epsilon. Additionally, suppressing messages in `happi-intro.Rmd` when npLRT is run.